### PR TITLE
Remove typings dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Make your own nested error types!",
   "main": "dist/index.js",
   "files": [
-    "dist/",
-    "typings.json",
-    "LICENSE"
+    "dist/"
   ],
   "scripts": {
     "lint": "tslint \"src/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tslint": "^3.10.2",
     "tslint-config-standard": "^1.0.0",
     "typescript": "^1.7.3",
-    "typings": "^1.0.2"
+    "typings": "^1.3.1"
   },
   "dependencies": {
     "make-error": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "typings": "^1.0.2"
   },
   "dependencies": {
-    "make-error": "^1.1.1"
+    "make-error": "^1.2.0"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,4 @@
 {
-  "dependencies": {
-    "make-error": "github:typings/typed-make-error#310953e35a2c6927b5743dc2d2215384d056fa7a"
-  },
   "devDependencies": {
     "blue-tape": "github:typings/typed-blue-tape#a4e41a85d6f760e7c60088127968eae7d3a556fa"
   },


### PR DESCRIPTION
`make-error@1.2.0` now comes with typings, so `typings.json` is no longer needed for distribution.

Also, "LICENSE" is always included thus no need to keep in the `files: []` array.

Also updated `typings` version to 1.3.1

🌷 