### PR TITLE
perf(es6): Update code to es6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@
 
 > Make your own nested error types!
 
+## 2.0 upgrade note
+
+`make-error-cause@2.0` is converted to es2016 module.
+This means the way to reference `make-error-cause` has slightly changed:
+
+```ts
+// In 1.x
+import makeErrorCause = require('make-error-cause');
+
+// In 2.0
+import makeErrorCause from 'make-error-cause';
+
+// if using `require()` syntax
+import makeErrorCauseModule = require('make-error-cause');
+const makeErrorCause = makeErrorCause.default;
+
+// For CommonJS JavaScript
+const makeErrorCauseModule = require('make-error-cause');
+const makeErrorCause = makeErrorCause.default;
+```
+
 ## Features
 
 * Compatible with Node and browsers

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## 2.0 upgrade note
 
-`make-error-cause@2.0` is converted to es2016 module.
+`make-error-cause@2.0` is converted to es2015 module.
 This means the way to reference `make-error-cause` has slightly changed:
 
 ```ts

--- a/src/index.es6.spec.ts
+++ b/src/index.es6.spec.ts
@@ -1,9 +1,9 @@
 import test = require('blue-tape')
-import makeErrorCause = require('./index')
+import makeErrorCause, { BaseError } from './index'
 
 test('make error cause', t => {
-  const TestError = makeErrorCause.default('TestError')
-  const SubTestError = makeErrorCause.default('SubTestError', TestError)
+  const TestError = makeErrorCause('TestError')
+  const SubTestError = makeErrorCause('SubTestError', TestError)
 
   t.test('render the cause', t => {
     const cause = new Error('boom!')
@@ -13,13 +13,13 @@ test('make error cause', t => {
     t.equal(error.cause, cause)
     t.equal(error.toString(), 'TestError: something bad\nCaused by: Error: boom!')
     t.ok(error instanceof Error)
-    t.ok(error instanceof makeErrorCause.BaseError)
+    t.ok(error instanceof BaseError)
     t.ok(error instanceof TestError)
 
     t.equal(again.cause, error)
     t.equal(again.toString(), 'SubTestError: more bad\nCaused by: TestError: something bad\nCaused by: Error: boom!')
     t.ok(again instanceof Error)
-    t.ok(again instanceof makeErrorCause.BaseError)
+    t.ok(again instanceof BaseError)
     t.ok(again instanceof TestError)
     t.ok(again instanceof SubTestError)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,31 @@
 import makeError = require('make-error')
 
-function makeErrorCause (value: string | Function): makeErrorCause.Constructor<makeErrorCause.BaseError>
-function makeErrorCause <T extends Error> (
+export default function makeErrorCause (value: string | Function): Constructor<BaseError>
+export default function makeErrorCause <T extends Error> (
   value: string | Function,
   _super: { new (...args: any[]): T }
-): makeErrorCause.Constructor<T>
-function makeErrorCause <T extends Error> (
+): Constructor<T>
+export default function makeErrorCause <T extends Error> (
   value: string | Function,
-  _super: { new (...args: any[]): T } = makeErrorCause.BaseError as any
-): makeErrorCause.Constructor<T> {
+  _super: { new (...args: any[]): T } = BaseError as any
+): Constructor<T> {
   return makeError(value, _super)
 }
 
-namespace makeErrorCause {
+export class BaseError extends makeError.BaseError {
 
-  export class BaseError extends makeError.BaseError {
-
-    constructor (message: string, public cause?: Error) {
-      super(message)
-    }
-
-    toString () {
-      return super.toString() + (this.cause ? `\nCaused by: ${this.cause.toString()}` : '')
-    }
-
+  constructor (message: string, public cause?: Error) {
+    super(message)
   }
 
-  export interface Constructor <T> {
-    new (message: string, cause?: Error): T
-    super_: any
-    prototype: T
+  toString () {
+    return super.toString() + (this.cause ? `\nCaused by: ${this.cause.toString()}` : '')
   }
 
 }
 
-export = makeErrorCause
+export interface Constructor <T> {
+  new (message: string, cause?: Error): T
+  super_: any
+  prototype: T
+}


### PR DESCRIPTION
Breaking change: commonjs need to do this instead:

```js
const makeErrorCause = require('make-error-cause')

const TestError = makeErrorCause.default('TestError')
```

The good thing is es6 consumption improved (thus mostly avoid the ES6<->commonjs interop issue):

```ts
import makeErrorCause, { BaseError } from 'make-error-cause'

```