### PR TITLE
set sourceRoot

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "removeComments": true,
     "declaration": true,
     "sourceMap": true,
+    "sourceRoot": "/make-error-cause",
     "inlineSources": true,
     "newLine": "LF"
   },


### PR DESCRIPTION
Without source root, when the module is bundled and used in the browser, the source map does not provide useful information about the module and easily mix up with other modules.

![image](https://cloud.githubusercontent.com/assets/3254987/21839891/216452a6-d78f-11e6-9089-65011398e7eb.png)
The "../src/" is the folder for `make-error-cause`.

If sourceRoot is set, it will show up like this:
![image](https://cloud.githubusercontent.com/assets/3254987/21840333/ce41a454-d791-11e6-8c1e-97de4a55e2d1.png)

