### PR TITLE
Mark message optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export const SEPARATOR_TEXT = `\n\nThe following exception was the direct cause 
 
 export class BaseError extends makeError.BaseError {
 
-  constructor (message: string, public cause?: Error) {
+  constructor (message?: string, public cause?: Error) {
     super(message)
   }
 


### PR DESCRIPTION
`message` is not required by `make-error` either.